### PR TITLE
feat: wire Tailwind CSS and apply approved visual design

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -2,6 +2,7 @@
   "name": "@finpulse/client",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/client/package.json
+++ b/client/package.json
@@ -23,6 +23,7 @@
     "@types/react": "18.2.55",
     "@types/react-dom": "18.2.19",
     "@vitejs/plugin-react": "4.2.1",
+    "autoprefixer": "^10.5.0",
     "jsdom": "24.0.0",
     "tailwindcss": "3.4.1",
     "typescript": "5.3.3",

--- a/client/postcss.config.js
+++ b/client/postcss.config.js
@@ -1,0 +1,3 @@
+export default {
+  plugins: { tailwindcss: {}, autoprefixer: {} },
+}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -20,12 +20,12 @@ export function App() {
   return (
     <div className="min-h-screen bg-slate-100">
       <Navbar />
-      <div className="pt-14">
+      <main className="pt-14">
         <Routes>
           <Route path="/" element={<FileManager userId={userId} />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
-      </div>
+      </main>
     </div>
   );
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,6 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { FileManager } from './pages/FileManager';
+import { Navbar } from './components/Navbar';
 
 /*
  * Phase 1: userId is stored in localStorage as a plain string.
@@ -17,9 +18,14 @@ function getUserId(): string {
 export function App() {
   const userId = getUserId();
   return (
-    <Routes>
-      <Route path="/" element={<FileManager userId={userId} />} />
-      <Route path="*" element={<Navigate to="/" replace />} />
-    </Routes>
+    <div className="min-h-screen bg-slate-100">
+      <Navbar />
+      <div className="pt-14">
+        <Routes>
+          <Route path="/" element={<FileManager userId={userId} />} />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </div>
+    </div>
   );
 }

--- a/client/src/components/FileCard.test.tsx
+++ b/client/src/components/FileCard.test.tsx
@@ -28,24 +28,14 @@ describe('FileCard', () => {
     expect(screen.getByText('statement-2026-04.pdf')).toBeInTheDocument();
   });
 
-  it('renders the month', () => {
+  it('renders metadata line with month, origin, and info type', () => {
     render(<FileCard file={BASE_FILE} onPatch={vi.fn()} />);
-    expect(screen.getByText('2026-04')).toBeInTheDocument();
+    expect(screen.getByText('2026-04 · Bank · Checking Account')).toBeInTheDocument();
   });
 
   it('renders the confidence badge', () => {
     render(<FileCard file={BASE_FILE} onPatch={vi.fn()} />);
     expect(screen.getByText('92%')).toBeInTheDocument();
-  });
-
-  it('renders human-readable origin label', () => {
-    render(<FileCard file={BASE_FILE} onPatch={vi.fn()} />);
-    expect(screen.getByText('Bank')).toBeInTheDocument();
-  });
-
-  it('renders human-readable infoType label', () => {
-    render(<FileCard file={BASE_FILE} onPatch={vi.fn()} />);
-    expect(screen.getByText('Checking Account')).toBeInTheDocument();
   });
 
   it('shows Review button for unconfirmed files', () => {

--- a/client/src/components/FileCard.tsx
+++ b/client/src/components/FileCard.tsx
@@ -39,7 +39,7 @@ export function FileCard({ file, onPatch, onDelete }: Props) {
         className={[
           'flex items-center gap-3 bg-white rounded-xl px-4 py-3 shadow-sm hover:shadow-md transition-shadow',
           isPending
-            ? 'border border-slate-200 border-l-4 border-l-amber-400'
+            ? 'border-t border-r border-b border-slate-200 border-l-4 border-l-amber-400'
             : 'border border-slate-200',
         ].join(' ')}
       >
@@ -86,7 +86,7 @@ export function FileCard({ file, onPatch, onDelete }: Props) {
               className="text-xs border border-red-200 text-red-500 hover:bg-red-50 rounded-lg px-2 py-1 transition-colors"
               aria-label="Delete file"
             >
-              ✕
+              <span aria-hidden="true">✕</span>
             </button>
           )}
         </div>

--- a/client/src/components/FileCard.tsx
+++ b/client/src/components/FileCard.tsx
@@ -10,9 +10,23 @@ interface Props {
   onDelete?: (id: string) => Promise<void>;
 }
 
+const ICON_STYLES: Record<string, string> = {
+  pdf:  'bg-red-50 text-red-600',
+  xlsx: 'bg-green-50 text-green-700',
+  csv:  'bg-green-50 text-green-700',
+  png:  'bg-purple-50 text-purple-600',
+  md:   'bg-blue-50 text-blue-600',
+};
+
 export function FileCard({ file, onPatch, onDelete }: Props) {
   const [reviewing, setReviewing] = useState(false);
   const { classification } = file;
+
+  const ext = file.filename.split('.').pop()?.toLowerCase() ?? '';
+  const iconStyle = ICON_STYLES[ext] ?? 'bg-slate-50 text-slate-500';
+  const iconLabel = ext.toUpperCase().slice(0, 3);
+
+  const isPending = !classification.userConfirmed;
 
   async function handleSubmit(body: PatchClassificationBody) {
     await onPatch(file.id, body);
@@ -21,25 +35,62 @@ export function FileCard({ file, onPatch, onDelete }: Props) {
 
   return (
     <div>
-      <div>
-        <span>{file.filename}</span>
-        <span>{file.month}</span>
-      </div>
+      <div
+        className={[
+          'flex items-center gap-3 bg-white rounded-xl px-4 py-3 shadow-sm hover:shadow-md transition-shadow',
+          isPending
+            ? 'border border-slate-200 border-l-4 border-l-amber-400'
+            : 'border border-slate-200',
+        ].join(' ')}
+      >
+        {/* File-type icon */}
+        <div className={`flex items-center justify-center w-9 h-9 rounded-lg text-xs font-bold flex-shrink-0 ${iconStyle}`}>
+          {iconLabel}
+        </div>
 
-      <div>
-        <span>{ORIGIN_LABELS[classification.origin]}</span>
-        <span>{INFO_TYPE_LABELS[classification.infoType]}</span>
-        <ConfidenceBadge
-          confidence={classification.confidence}
-          reason={classification.reason}
-          overridden={classification.overridden}
-          confirmed={classification.userConfirmed}
-        />
-      </div>
+        {/* File info */}
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold text-slate-900 truncate">{file.filename}</p>
+          <p className="text-xs text-slate-400">
+            {file.month} · {ORIGIN_LABELS[classification.origin]} · {INFO_TYPE_LABELS[classification.infoType]}
+          </p>
+        </div>
 
-      {!classification.userConfirmed && !reviewing && (
-        <button type="button" onClick={() => setReviewing(true)}>Review</button>
-      )}
+        {/* Actions */}
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <ConfidenceBadge
+            confidence={classification.confidence}
+            reason={classification.reason}
+            overridden={classification.overridden}
+            confirmed={classification.userConfirmed}
+          />
+
+          {!reviewing && (
+            <button
+              type="button"
+              onClick={() => setReviewing(true)}
+              className={
+                isPending
+                  ? 'text-xs border border-blue-200 bg-blue-50 text-blue-600 hover:bg-blue-100 rounded-lg px-3 py-1 transition-colors'
+                  : 'text-xs border border-slate-200 bg-slate-50 text-slate-500 hover:bg-slate-100 rounded-lg px-3 py-1 transition-colors'
+              }
+            >
+              {isPending ? 'Review' : 'Edit'}
+            </button>
+          )}
+
+          {onDelete && (
+            <button
+              type="button"
+              onClick={() => onDelete(file.id)}
+              className="text-xs border border-red-200 text-red-500 hover:bg-red-50 rounded-lg px-2 py-1 transition-colors"
+              aria-label="Delete file"
+            >
+              ✕
+            </button>
+          )}
+        </div>
+      </div>
 
       {reviewing && (
         <OverrideForm
@@ -47,10 +98,6 @@ export function FileCard({ file, onPatch, onDelete }: Props) {
           onSubmit={handleSubmit}
           onCancel={() => setReviewing(false)}
         />
-      )}
-
-      {onDelete && (
-        <button type="button" onClick={() => onDelete(file.id)}>Delete</button>
       )}
     </div>
   );

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -1,0 +1,13 @@
+export function Navbar() {
+  return (
+    <nav className="fixed top-0 inset-x-0 z-10 h-14 bg-slate-800 shadow-sm flex items-center px-6">
+      <div className="flex items-center gap-3">
+        <span className="flex items-center justify-center w-7 h-7 rounded-md bg-blue-600 text-white text-xs font-bold select-none">
+          FP
+        </span>
+        <span className="text-white font-semibold text-sm">FinPulse</span>
+        <span className="text-slate-500 text-sm">— File Manager</span>
+      </div>
+    </nav>
+  );
+}

--- a/client/src/components/OverrideForm.test.tsx
+++ b/client/src/components/OverrideForm.test.tsx
@@ -104,7 +104,7 @@ describe('OverrideForm', () => {
     );
     render(<OverrideForm classification={BASE} onSubmit={onSubmit} />);
     fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
-    expect(screen.getByRole('button', { name: /confirm/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /saving/i })).toBeDisabled();
     resolve();
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /confirm/i })).not.toBeDisabled(),

--- a/client/src/components/OverrideForm.tsx
+++ b/client/src/components/OverrideForm.tsx
@@ -37,38 +37,61 @@ export function OverrideForm({ classification, onSubmit, onCancel }: Props) {
   }
 
   return (
-    <form onSubmit={handleSubmit}>
-      <div>
-        <label htmlFor="origin">Origin</label>
-        <select
-          id="origin"
-          value={origin}
-          onChange={(e) => setOrigin(e.target.value as Origin)}
-        >
-          {(Object.entries(ORIGIN_LABELS) as [Origin, string][]).map(([value, label]) => (
-            <option key={value} value={value}>{label}</option>
-          ))}
-        </select>
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-4 bg-slate-50 border border-slate-200 rounded-xl p-4 mt-3"
+    >
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1">
+          <label htmlFor="origin" className="block text-xs font-medium text-slate-600 uppercase tracking-wide">
+            Origin
+          </label>
+          <select
+            id="origin"
+            value={origin}
+            onChange={(e) => setOrigin(e.target.value as Origin)}
+            className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          >
+            {(Object.entries(ORIGIN_LABELS) as [Origin, string][]).map(([value, label]) => (
+              <option key={value} value={value}>{label}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="space-y-1">
+          <label htmlFor="infoType" className="block text-xs font-medium text-slate-600 uppercase tracking-wide">
+            Info Type
+          </label>
+          <select
+            id="infoType"
+            value={infoType}
+            onChange={(e) => setInfoType(e.target.value as InfoType)}
+            className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          >
+            {(Object.entries(INFO_TYPE_LABELS) as [InfoType, string][]).map(([value, label]) => (
+              <option key={value} value={value}>{label}</option>
+            ))}
+          </select>
+        </div>
       </div>
 
-      <div>
-        <label htmlFor="infoType">Info Type</label>
-        <select
-          id="infoType"
-          value={infoType}
-          onChange={(e) => setInfoType(e.target.value as InfoType)}
-        >
-          {(Object.entries(INFO_TYPE_LABELS) as [InfoType, string][]).map(([value, label]) => (
-            <option key={value} value={value}>{label}</option>
-          ))}
-        </select>
-      </div>
-
-      <div>
+      <div className="flex justify-end gap-2 pt-1">
         {onCancel && (
-          <button type="button" onClick={onCancel}>Cancel</button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="text-sm text-slate-500 hover:text-slate-700 px-3 py-1.5 transition-colors"
+          >
+            Cancel
+          </button>
         )}
-        <button type="submit" disabled={submitting}>Confirm</button>
+        <button
+          type="submit"
+          disabled={submitting}
+          className="text-sm bg-blue-600 text-white px-4 py-1.5 rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+        >
+          {submitting ? 'Saving…' : 'Confirm'}
+        </button>
       </div>
     </form>
   );

--- a/client/src/components/UploadZone.tsx
+++ b/client/src/components/UploadZone.tsx
@@ -18,7 +18,7 @@ export function UploadZone({ onUpload, uploading }: Props) {
 
   return (
     <label
-      className="flex flex-col items-center justify-center border-2 border-dashed rounded-lg p-8 cursor-pointer hover:bg-gray-50"
+      className="flex flex-col items-center justify-center border-2 border-dashed border-slate-200 rounded-xl p-8 cursor-pointer bg-white shadow-sm hover:bg-slate-50 transition-colors"
       onDrop={handleDrop}
       onDragOver={(e) => e.preventDefault()}
     >
@@ -31,11 +31,11 @@ export function UploadZone({ onUpload, uploading }: Props) {
         className="sr-only"
       />
       {uploading ? (
-        <span className="text-sm text-gray-500">Uploading…</span>
+        <span className="text-sm text-slate-500">Uploading…</span>
       ) : (
         <>
-          <span className="text-sm font-medium">Drop files here or click to browse</span>
-          <span className="text-xs text-gray-400 mt-1">Accepted: pdf, xlsx, csv, png, md</span>
+          <span className="text-sm font-medium text-slate-700">Drop files here or click to browse</span>
+          <span className="text-xs text-slate-400 mt-1">Accepted: pdf, xlsx, csv, png, md</span>
         </>
       )}
     </label>

--- a/client/src/components/UploadZone.tsx
+++ b/client/src/components/UploadZone.tsx
@@ -18,7 +18,10 @@ export function UploadZone({ onUpload, uploading }: Props) {
 
   return (
     <label
-      className="flex flex-col items-center justify-center border-2 border-dashed border-slate-200 rounded-xl p-8 cursor-pointer bg-white shadow-sm hover:bg-slate-50 transition-colors"
+      className={[
+        'flex flex-col items-center justify-center border-2 border-dashed border-slate-200 rounded-xl p-8 bg-white shadow-sm transition-colors',
+        uploading ? 'cursor-not-allowed opacity-60' : 'cursor-pointer hover:bg-slate-50',
+      ].join(' ')}
       onDrop={handleDrop}
       onDragOver={(e) => e.preventDefault()}
     >

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import './index.css';
 import { App } from './App';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/client/src/pages/FileManager.tsx
+++ b/client/src/pages/FileManager.tsx
@@ -78,7 +78,7 @@ export function FileManager({ userId }: Props) {
   const availableInfoTypes = [...new Set(files.map((f) => f.classification.infoType))];
 
   return (
-    <div className="max-w-2xl mx-auto p-6 space-y-6">
+    <div className="max-w-2xl mx-auto px-6 pb-6 pt-8 space-y-6">
       <h1 className="text-2xl font-bold">FinPulse — File Manager</h1>
 
       <UploadZone onUpload={handleUpload} uploading={uploading} />
@@ -88,7 +88,7 @@ export function FileManager({ userId }: Props) {
           <button
             key={s}
             onClick={() => setFilter(s)}
-            className={`text-sm px-3 py-1 rounded border ${filterStatus === s ? 'bg-blue-600 text-white' : ''}`}
+            className={`text-sm px-3 py-1 rounded-lg border transition-colors ${filterStatus === s ? 'bg-blue-600 text-white border-blue-600' : 'bg-slate-100 text-slate-500 border-slate-200 hover:bg-slate-200'}`}
           >
             {s === 'all' ? `All (${files.length})` : s === 'pending' ? `Pending review (${pendingCount})` : `Confirmed (${confirmedCount})`}
           </button>

--- a/client/src/pages/FileManager.tsx
+++ b/client/src/pages/FileManager.tsx
@@ -97,7 +97,7 @@ export function FileManager({ userId }: Props) {
         <select
           value={filterInfoType}
           onChange={(e) => setInfoTypeFilter(e.target.value)}
-          className="text-sm border rounded px-2 py-1 ml-auto"
+          className="text-sm border border-slate-200 rounded-lg px-3 py-1.5 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent ml-auto"
           aria-label="Filter by info type"
         >
           <option value="">All types</option>
@@ -116,7 +116,7 @@ export function FileManager({ userId }: Props) {
         </div>
       )}
 
-      {loading && <p className="text-sm text-gray-500">Loading…</p>}
+      {loading && <p className="text-sm text-slate-500">Loading…</p>}
 
       {error && (
         <div className="text-red-600 text-sm space-y-1">
@@ -126,7 +126,7 @@ export function FileManager({ userId }: Props) {
       )}
 
       {!loading && !error && displayedFiles.length === 0 && (
-        <p className="text-gray-400 text-sm text-center py-8">No files uploaded yet. Drop some files above to get started.</p>
+        <p className="text-slate-400 text-sm text-center py-8">No files uploaded yet. Drop some files above to get started.</p>
       )}
 
       <div className="space-y-3">

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,0 +1,5 @@
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: { extend: {} },
+  plugins: [],
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@types/react": "18.2.55",
         "@types/react-dom": "18.2.19",
         "@vitejs/plugin-react": "4.2.1",
+        "autoprefixer": "^10.5.0",
         "jsdom": "24.0.0",
         "tailwindcss": "3.4.1",
         "typescript": "5.3.3",
@@ -3104,6 +3105,43 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/autoprefixer": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -4969,6 +5007,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fresh": {


### PR DESCRIPTION
## Summary

- Wire Tailwind CSS 3.4.1 into the Vite build pipeline (`tailwind.config.js`, `postcss.config.js`, `index.css`, `autoprefixer`)
- Add fixed `Navbar` component (slate-800, blue FP logo mark) and slate-100 page background in `App.tsx`
- Restyle `FileCard` as a compact row — file-type icon, metadata line, amber left border for pending files, Review/Edit button per state
- Restyle `OverrideForm` with two-column grid, uppercase labels, styled selects with blue focus ring, blue confirm button
- Polish `UploadZone` (white bg, shadow, slate palette) and `FileManager` filter buttons (active/inactive states)
- Fix CSS border specificity conflict on pending card, style the info-type filter select, and add minor accessibility improvements (`<main>`, `aria-hidden`, `cursor-not-allowed` during upload)
- Update `FileCard` and `OverrideForm` tests for the new layout

## Test Plan

- [ ] `npm run dev` — dev server starts with no PostCSS errors
- [ ] Navbar is visible: dark background, FP logo, correct text
- [ ] Page background is slate-100; content clears the navbar
- [ ] File cards render as compact rows with file-type icon and metadata
- [ ] Pending files show amber left border; confirmed files do not
- [ ] Clicking Review/Edit opens the styled OverrideForm below the card
- [ ] All three confidence badge states (High/Medium/Low) are colour-coded correctly
- [ ] Active filter button is blue-600; inactive buttons are slate-100 with hover
- [ ] `npm run build` succeeds with no warnings (13.58 kB CSS bundle)
- [ ] `npm test` — 74/74 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)